### PR TITLE
Fixed unhandled issue where create method could be invoked before DOM had finished loading

### DIFF
--- a/vanillatoasts.js
+++ b/vanillatoasts.js
@@ -15,78 +15,89 @@
     window.addEventListener('DOMContentLoaded', init);
   }
 
+  // Create VanillaToasts object
+  VanillaToasts = {
+    // In case toast creation is attempted before dom has finished loading!
+    create: function() {
+      console.error([
+        'DOM has not finished loading.',
+        '\tInvoke create method when DOM\s readyState is complete'
+      ].join('\n'))
+    }
+  };
+  var autoincrement = 0;
+
   // Initialize library
   function init() {
     // Toast container
     var container = document.createElement('div');
     container.id = 'vanillatoasts-container';
     document.body.appendChild(container);
+
+    // @Override
+    // Replace create method when DOM has finished loading
+    VanillaToasts.create = function(options) {
+      var toast = document.createElement('div');
+      toast.id = ++autoincrement;
+      toast.id = 'toast-' + toast.id;
+      toast.className = 'vanillatoasts-toast';
+
+      // title
+      if (options.title) {
+        var h4 = document.createElement('h4');
+        h4.className = 'vanillatoasts-title';
+        h4.innerHTML = options.title;
+        toast.appendChild(h4);
+      }
+
+      // text
+      if (options.text) {
+        var p = document.createElement('p');
+        p.className = 'vanillatoasts-text';
+        p.innerHTML = options.text;
+        toast.appendChild(p);
+      }
+
+      // icon
+      if (options.icon) {
+        var img = document.createElement('img');
+        img.src = options.icon;
+        img.className = 'vanillatoasts-icon';
+        toast.appendChild(img);
+      }
+
+      // click callback
+      if (typeof options.callback === 'function') {
+        toast.addEventListener('click', options.callback);
+      }
+
+      // toast api
+      toast.hide = function() {
+        toast.className += ' vanillatoasts-fadeOut';
+        toast.addEventListener('animationend', removeToast, false);
+      };
+
+      // autohide
+      if (options.timeout) {
+        setTimeout(toast.hide, options.timeout);
+      }
+
+      if (options.type) {
+        toast.className += ' vanillatoasts-' + options.type;
+      }
+
+      toast.addEventListener('click', toast.hide);
+
+
+      function removeToast() {
+        document.getElementById('vanillatoasts-container').removeChild(toast);
+      }
+
+      document.getElementById('vanillatoasts-container').appendChild(toast);
+      return toast;
+
+    }
   }
-
-  var VanillaToasts = {};
-  var autoincrement = 0;
-
-  VanillaToasts.create = function(options) {
-    var toast = document.createElement('div');
-    toast.id = ++autoincrement;
-    toast.id = 'toast-' + toast.id;
-    toast.className = 'vanillatoasts-toast';
-
-    // title
-    if (options.title) {
-      var h4 = document.createElement('h4');
-      h4.className = 'vanillatoasts-title';
-      h4.innerHTML = options.title;
-      toast.appendChild(h4);
-    }
-
-    // text
-    if (options.text) {
-      var p = document.createElement('p');
-      p.className = 'vanillatoasts-text';
-      p.innerHTML = options.text;
-      toast.appendChild(p);
-    }
-
-    // icon
-    if (options.icon) {
-      var img = document.createElement('img');
-      img.src = options.icon;
-      img.className = 'vanillatoasts-icon';
-      toast.appendChild(img);
-    }
-
-    // click callback
-    if (typeof options.callback === 'function') {
-      toast.addEventListener('click', options.callback);
-    }
-
-    // toast api
-    toast.hide = function() {
-      toast.className += ' vanillatoasts-fadeOut';
-      toast.addEventListener('animationend', removeToast, false);
-    };
-
-    // autohide
-    if (options.timeout) {
-      setTimeout(toast.hide, options.timeout);
-    }
-
-    if (options.type) {
-      toast.className += ' vanillatoasts-' + options.type;
-    }
-
-    toast.addEventListener('click', toast.hide);
-
-
-    function removeToast() {
-      document.getElementById('vanillatoasts-container').removeChild(toast);
-    }
-
-    document.getElementById('vanillatoasts-container').appendChild(toast);
-    return toast;
-
-  };
 
   return VanillaToasts;
 


### PR DESCRIPTION
Added an initial declaration of the create method to the VanillaToasts object, which gets overridden once the DOM has finished loading. Moved the scope of VanillaToast.create's second definition to inside of the init function.
