### PR TITLE
add specific styling for h4

### DIFF
--- a/vanillatoasts.css
+++ b/vanillatoasts.css
@@ -26,7 +26,8 @@
   animation-fill-mode: forwards;
 }
 
-#vanillatoasts-container p, h4 {
+#vanillatoasts-container p,
+#vanillatoasts-container h4 {
   margin: 3px 0!important;
 }
 


### PR DESCRIPTION
At the moment the h4 styling is very generic and uses !important rule which will override all h4 tags on the page. This can cause unintended styling issues and to override this users has to add !important when they want to style their h4 tags.

This fix adds the vanillatoasts id before the h4 to add more specific rules to ensure it does not affect other h4 tags on the site