### PR TITLE
New function to manually begin the timeout of a toast

### DIFF
--- a/vanillatoasts.js
+++ b/vanillatoasts.js
@@ -27,7 +27,15 @@
         'DOM has not finished loading.',
         '\tInvoke create method when DOM\s readyState is complete'
       ].join('\n'))
-    }
+    },
+    //function to manually set timeout after create
+    setTimeout: function() {
+      console.error([
+        'DOM has not finished loading.',
+        '\tInvoke create method when DOM\s readyState is complete'
+      ].join('\n'))
+    },
+    toasts: {} //store toasts to modify later
   };
   var autoincrement = 0;
 
@@ -95,11 +103,27 @@
 
       function removeToast() {
         document.getElementById('vanillatoasts-container').removeChild(toast);
+        delete VanillaToasts.toasts[toast.id];  //remove toast from object
       }
 
       document.getElementById('vanillatoasts-container').appendChild(toast);
-      return toast;
 
+      //add toast to object so its easily gettable by its id
+      VanillaToasts.toasts[toast.id] = toast;
+
+      return toast;
+    }
+
+    /*
+    custom function to manually initiate timeout of
+    the toast.  Useful if toast is created as persistant
+    because we don't want it to start to timeout until
+    we tell it to
+    */
+    VanillaToasts.setTimeout = function(toastid, val) {
+      if(VanillaToasts.toasts[toastid]){
+        setTimeout(VanillaToasts.toasts[toastid].hide, val);
+      }
     }
   }
 


### PR DESCRIPTION
Added setTimeout(toastId) function which we can call to manually begin the timeout of a toast which was created without the timeout option set.  This allows us to create persistent toasts initially, but begin a timeout on some event.

Use case example:  We are creating a tabbed page and the toast pops up on a tab we are not currently on, so we cannot see it.  If the toast was created with a timeout, it might have already disappeared by the time we open that tab.

With this function, we can create the toast without a timeout option, making it persistent and when we open that tab and the toast becomes visible on screen, we can manually begin the timeout process for the given toast id.