### PR TITLE
Include vanillatoasts.css in bower.json main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "vanillatoasts",
-  "main": "vanillatoasts.js",
+  "main": [
+    "vanillatoasts.js",
+    "vanillatoasts.css"
+  ],
   "version": "1.0.1",
   "authors": [
     "AlexKvazos <contact@alexkvazos.com>"


### PR DESCRIPTION
Main supports array of strings for files that the package requires. In a tool such as https://www.npmjs.com/package/grunt-bower-install. I think would make more sense to require the user to override main to avoid exclude the css rather than include an override to include the css.