### PR TITLE
Add z-index to container

### DIFF
--- a/vanillatoasts.css
+++ b/vanillatoasts.css
@@ -4,6 +4,7 @@
   right: 0;
   width: 320px;
   font-family: 'Helvetica';
+  z-index: 1031;
 }
 
 .vanillatoasts-toast {


### PR DESCRIPTION
At least one tool, Bootstrap, puts fixed page headers at he 1030 z-index level. Without this change, the toast appears behind the page header. I think there are probably other development tools and platforms that do the same thing with the z-index on page headers. It is possible that someone else may discover a need for an even higher number.