### PR TITLE
Single option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ let toast = VanillaToasts.create({
   type: 'warning', // success, info, warning, error   / optional parameter
   icon: '/img/alert-icon.jpg', // optional parameter
   timeout: 5000, // hide after 5000ms, // optional parameter
+  single: false, // show always single notification
   callback: function() { ... } // executed when toast is clicked / optional parameter
 });
 

--- a/vanillatoasts.js
+++ b/vanillatoasts.js
@@ -53,6 +53,14 @@
       toast.id = ++autoincrement;
       toast.id = 'toast-' + toast.id;
       toast.className = 'vanillatoasts-toast';
+      
+      // single
+       if (options.single === true) {
+              var elements = document.getElementsByClassName('vanillatoasts-toast');
+              while (elements.length > 0) {
+                  elements[0].parentNode.removeChild(elements[0]);
+            }
+        }
 
       // title
       if (options.title) {

--- a/vanillatoasts.js
+++ b/vanillatoasts.js
@@ -77,6 +77,10 @@
         p.innerHTML = options.text;
         toast.appendChild(p);
       }
+      
+      if (options.onHide) {
+        // do something         
+      }
 
       // icon
       if (options.icon) {
@@ -121,6 +125,10 @@
       toast.hide = function () {
         toast.className += ' vanillatoasts-fadeOut';
         toast.addEventListener('animationend', removeToast, false);
+        
+        if (options.onHide) {
+            options.onHide();
+        }
       };
 
       // autohide


### PR DESCRIPTION
This PR adds to `single `option to the plugin which allows to user create a single notification always.
Once a notification opens, other notifications hides

```
let options = {
        title: 'User Deletion',
        text: 'User deleted',
        single: true,
        type: 'success',
        timeout: 3000,
        callback: function () {
           //
        }
    };

VanillaToasts.create(options);
```